### PR TITLE
Increase BU-Schluessel limit to 4

### DIFF
--- a/lib/datev/base/booking.rb
+++ b/lib/datev/base/booking.rb
@@ -59,7 +59,7 @@ module Datev
     end
 
     # 9
-    field 'BU-Schlüssel', :string, limit: 2
+    field 'BU-Schlüssel', :string, limit: 4
     # Steuerschlüssel und/oder Berichtigungsschlüssel
 
     # 10


### PR DESCRIPTION
According to http://www.datev.de/dnlexom/client/app/index.html#/document/1003221 BU-Schlüssel now has a limit of 4