### PR TITLE
Increase limit of fields KOST1 and KOST2 to 36

### DIFF
--- a/lib/datev/base/booking.rb
+++ b/lib/datev/base/booking.rb
@@ -152,11 +152,11 @@ module Datev
     # Buchungsspezifische Inhalte zu den oben genannten Informationsarten
 
     # 37
-    field 'KOST1 – Kostenstelle', :string, limit: 8
+    field "KOST1 – Kostenstelle", :string, limit: 36
     # Über KOST1 erfolgt die Zuordnung des Geschäftsvorfalls für die anschließende Kostenrechnung.
 
     # 38
-    field 'KOST2 – Kostenstelle', :string, limit: 8
+    field "KOST2 – Kostenstelle", :string, limit: 36
     # Über KOST2 erfolgt die Zuordnung des Geschäftsvorfalls für die anschließende Kostenrechnung.
 
     # 39


### PR DESCRIPTION
This PR increases the field length limit for KOST1 and KOST2 from 8 to 36 characters.

Changes:
- Updated KOST1 field limit in lib/datev/base/booking.rb
- Updated KOST2 field limit in lib/datev/base/booking.rb

Fixes #23 